### PR TITLE
Widen scope of optional chaining use

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ if let foo = foo {
 
 Optional chaining in Swift is similar to messaging `nil` in Objective-C, but in a way that works for any type, and that can be checked for success or failure.
 
-Use optional chaining if you want to assign a value to a property on an optional and you don’t plan on taking any alternative action if that optional is `nil`.
+Use optional chaining if you don’t plan on taking any alternative action if the optional is `nil`.
 
 ```Swift
 let cell: YourCell = tableView.ip_dequeueCell(indexPath)


### PR DESCRIPTION
Remove language implying that optional chaining should be used only for assigning values to properties on optionals.
