### PR TITLE
Change to guard styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,7 @@ Guard statements are meant to be used as early return logic only. They should no
 
 #####Single assignment `guard`
 ```Swift
-guard let value = someMethodThatReturnsOptional() else {
-    return nil
-}
+guard let value = someMethodThatReturnsOptional() else { return nil }
 ```
 
 #####Multi assignment `guard`
@@ -106,9 +104,27 @@ guard let value = someMethodThatReturnsOptional() else {
 guard
     let strongSelf = self,
     let foo = strongSelf.editing
-    else {
-        return
+    else { return }
+```
+
+#####Complex Returns `guard`
+This is any situation where you'd want to do more work in the guard than just return or throw.
+```Swift
+guard let value = someMethodThatReturnsOptional() else { 
+    doSomeNecessaryThing()
+    return nil 
 }
+```
+
+#####Complex Returns (Multi-assignment) `guard`
+```Swift
+guard
+    let strongSelf = self,
+    let foo = strongSelf.editing
+    else {
+    	doSomeNecessaryThing()
+        throw Error.FooUnknown 
+    }
 ```
 
 ##Classes, Structs, and Protocols

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ guard
     let strongSelf = self,
     let foo = strongSelf.editing
     else {
-    	doSomeNecessaryThing()
+        doSomeNecessaryThing()
         throw Error.FooUnknown 
     }
 ```


### PR DESCRIPTION
These are just my personal preferences, so I wanted to run them by people.
1. I think closing bracket should be in the same column as the beginning of the else's line, it it's going to be a multi-line `else`.
2. I think the `else` should only be multiline if you're doing something more complex within it than just returning.