### PR TITLE
Modify Dictionary following Apple guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,11 @@ func <|<<A>(lhs: A, rhs: A) -> A
 
 ### Dictionaries
 
-When specifying the type of a dictionary, always leave spaces on either side of the colon.
+When specifying the type of a dictionary, always leave one space after the colon, and no extra spaces around the brackets.
 
 ##### Like this:
 ```swift
-let capitals: [Country : City] = [Sweden : Stockholm]
+let capitals: [Country: City] = [Sweden: Stockholm]
 ```
 
 ###### Not this:
@@ -299,15 +299,15 @@ For literal dictionaries that exceed a single line, newline syntax is preferable
 
 ##### Like this:
 ```swift
-let capitals: [Country : City] = [
-    Sweden : Stockholm,
-    USA : WashingtonDC
+let capitals: [Country: City] = [
+    Sweden: Stockholm,
+    USA: WashingtonDC
 ]
 ```
 
 ###### Not this:
 ```swift
-let capitals: [Country : City] = [Sweden : Stockholm, USA : WashingtonDC]
+let capitals: [Country: City] = [Sweden: Stockholm, USA: WashingtonDC]
 ```
 
 ### Type Inference


### PR DESCRIPTION
This change is driven by newest version of Swiftlint 0.23.1, which generates warnings for the extra space before the colon (and thus a lot of project's Swift 4 conversion removed all of those), and Apple’s official documentation does not use extra space before colons https://developer.apple.com/documentation/swift/dictionary

The rationale behind the original divergence from official guideline was that the extra space before the colon distinguishes the dictionary type or literal declaration from a `param: value` syntax. However I personally fell that the square brackets are more standard and prominent differentiators between these two syntaxes, especially after we moved away from Objective C's bracket method call syntax. Swift strives for natural language-like syntax, and I think this is one of those details. Semantically the key value pair represents a relationship between the key and the value, and therefore the association is represented by a colon that is used as it is in regular English, which doesn’t have a space before it.