### PR TITLE
Exclude id from swiftlint identifier_name rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -155,3 +155,7 @@ file_length:
 
 nesting:
   type_level: 3
+
+identifier_name:
+  excluded:
+    - id


### PR DESCRIPTION
we could also exclude x, y, i if that's preferred