### PR TITLE
Update .swiftlint.yml for 0.30.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-# Compiled with 0.25.0 rules
+# Compiled with 0.30.1 rules
 
 # Don't add any files/directories to the 'include:' section. Everything not
 # listed under 'excluded:' should be linted.
@@ -29,6 +29,7 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 #   - custom_rules
 #   - discarded_notification_center_observer
 #   - discouraged_direct_init
+#   - duplicate_imports
 #   - dynamic_inline
 #   - empty_parameters
 #   - empty_parentheses_with_trailing_closure
@@ -41,16 +42,19 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 #   - generic_type_name
 #   - is_disjoint
 #   - identifier_name
+#   - inert_defer
 #   - implicit_getter
 #   - implicitly_unwrapped_optional
 #   - leading_whitespace
 #   - legacy_cggeometry_functions
 #   - legacy_constant
 #   - legacy_constructor
+#   - legacy_hashing
 #   - legacy_nsgeometry_functions
 #   - mark
 #   - nesting
 #   - notification_center_detachment
+#   - no_fallthrough_only
 #   - object_literal
 #   - opening_brace
 #   - operator_usage_whitespace
@@ -60,7 +64,9 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 #   - protocol_property_accessors_order
 #   - redundant_discardable_let
 #   - redundant_nil_coalescing
+#   - redundant_objc_attribute
 #   - redundant_optional_initialization
+#   - redundant_set_access_control
 #   - redundant_string_enum_value
 #   - return_arrow_whitespace
 #   - statement_position
@@ -75,8 +81,10 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 #   - type_name
 #   - unneeded_break_in_switch
 #   - unused_closure_parameter
+#   - unused_control_flow_label
 #   - unused_enumerated
 #   - unused_optional_binding
+#   - unused_setter_value
 #   - valid_ibinspectable
 #   - vertical_parameter_alignment
 #   - vertical_whitespace
@@ -84,16 +92,33 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 #   - xctfail_message
 
 opt_in_rules:
+  - anyobject_protocol
+  - closure_body_length
+  - collection_alignment
+  - convenience_type
+  - empty_xctest_method
   - explicit_init
   - fatal_error_message
+  - function_default_parameter_at_end
+  - identical_operands
   - joined_default_parameter
+  - legacy_random
+  - lower_acl_than_parent
   - multiline_arguments
+  - multiline_function_chains
   - multiline_parameters
+  - nslocalizedstring_key
   - overridden_super_call
   - prohibited_super_call
   - redundant_void_return
   - sorted_first_last
+  - static_operator
+  - strong_iboutlet
+  - unavailable_function
+  - unused_import
+  - unused_private_declaration
   - vertical_parameter_alignment_on_call
+  - xct_specific_matcher
 
 disabled_rules:
   - array_init
@@ -101,16 +126,25 @@ disabled_rules:
   - cyclomatic_complexity
   - discouraged_object_literal
   - discouraged_optional_boolean
+  - discouraged_optional_collection
   - empty_count
   - empty_enum_arguments
+  - empty_string
   - explicit_acl
+  - explicit_enum_raw_value
+  - explicit_self
   - explicit_top_level_acl
   - explicit_type_interface
   - extension_access_modifier
   - file_header
+  - file_name
   - for_where
   - implicit_return
   - let_var_whitespace
+  - missing_docs
+  - multiline_arguments_brackets
+  - multiline_literal_brackets
+  - multiline_parameters_brackets
   - nimble_operator
   - no_extension_access_modifier
   - no_grouping_extension
@@ -120,9 +154,11 @@ disabled_rules:
   - prefixed_toplevel_constant
   - private_action
   - private_over_fileprivate
+  - prohibited_interface_builder
   - quick_discouraged_call
   - quick_discouraged_focused_test
   - quick_discouraged_pending_test
+  - redundant_type_annotation
   - required_enum_case
   - single_test_class
   - sorted_imports
@@ -130,8 +166,11 @@ disabled_rules:
   - strict_fileprivate
   - switch_case_on_newline
   - todo
+  - toggle_bool
   - trailing_closure
   - unneeded_parentheses_in_closure_argument
+  - untyped_error_in_catch
+  - vertical_whitespace_between_cases
   - void_return
   - yoda_condition
 
@@ -140,9 +179,13 @@ disabled_rules:
   - function_body_length
   - function_parameter_count
   - large_tuple
+  - last_where
   - line_length
   - literal_expression_end_indentation
+  - modifier_order
   - multiple_closures_with_trailing_closure
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
 
 ## Rule Configuration
 
@@ -153,9 +196,12 @@ file_length:
   warning: 750
   error: 1500
 
-nesting:
-  type_level: 3
-
 identifier_name:
   excluded:
     - id
+
+lower_acl_than_parent:
+  severity: error
+
+nesting:
+  type_level: 3


### PR DESCRIPTION
Output of `swiftlint rules --config .swiftlint.yml` paired down to the ones that changed.

```
+------------------------------------------+------------------------+---------------+
| identifier                               | enabled in your config | configuration |
+------------------------------------------+------------------------+---------------+
| anyobject_protocol                       | yes                    | warning       |
| closure_body_length                      | yes                    | warning: 2... |
| collection_alignment                     | yes                    | warning, a... |
| convenience_type                         | yes                    | warning       |
| discouraged_optional_collection          | no                     | warning       |
| duplicate_imports                        | yes                    | warning       |
| empty_string                             | no                     | warning       |
| empty_xctest_method                      | yes                    | warning       |
| explicit_enum_raw_value                  | no                     | warning       |
| explicit_self                            | no                     | warning       |
| file_name                                | no                     | (severity)... |
| function_default_parameter_at_end        | yes                    | warning       |
| identical_operands                       | yes                    | warning       |
| inert_defer                              | yes                    | warning       |
| last_where                               | no                     | warning       |
| legacy_hashing                           | yes                    | warning       |
| legacy_random                            | yes                    | warning       |
| lower_acl_than_parent                    | yes                    | error         |
| missing_docs                             | no                     | warning: o... |
| modifier_order                           | no                     | warning, p... |
| multiline_arguments_brackets             | no                     | warning       |
| multiline_function_chains                | yes                    | warning       |
| multiline_literal_brackets               | no                     | warning       |
| multiline_parameters_brackets            | no                     | warning       |
| no_fallthrough_only                      | yes                    | warning       |
| nslocalizedstring_key                    | yes                    | warning       |
| prohibited_interface_builder             | no                     | warning       |
| redundant_objc_attribute                 | yes                    | warning       |
| redundant_set_access_control             | yes                    | warning       |
| redundant_type_annotation                | no                     | warning       |
| static_operator                          | yes                    | warning       |
| strong_iboutlet                          | yes                    | warning       |
| toggle_bool                              | no                     | warning       |
| unavailable_function                     | yes                    | warning       |
| untyped_error_in_catch                   | no                     | warning       |
| unused_control_flow_label                | yes                    | warning       |
| unused_import                            | yes                    | warning       |
| unused_private_declaration               | yes                    | warning       |
| unused_setter_value                      | yes                    | warning       |
| vertical_whitespace_between_cases        | no                     | warning       |
| vertical_whitespace_closing_braces       | no                     | N/A           |
| vertical_whitespace_opening_braces       | no                     | N/A           |
| xct_specific_matcher                     | yes                    | warning       |
+------------------------------------------+------------------------+---------------+
```

Screenshot of the rules and our decisions
<img width="1018" alt="screen shot 2019-02-07 at 5 05 19 pm" src="https://user-images.githubusercontent.com/293217/52445952-94506c80-2afa-11e9-8b4e-3f62b1f6bb2a.png">
